### PR TITLE
add Hebrew's old code "iw" to _BIDI_RTL_LANGS

### DIFF
--- a/lib/rtl-detect.js
+++ b/lib/rtl-detect.js
@@ -145,6 +145,7 @@ Object.defineProperty(self, '_BIDI_RTL_LANGS', {
         'fa',   /* 'فارسی', Persian */
         'glk',  /* 'گیلکی', Gilaki */
         'he',   /* 'עברית', Hebrew */
+        'iw',   /* 'עברית', Hebrew's old code */
         'ku',   /* 'Kurdî / كوردی', Kurdish */
         'mzn',  /* 'مازِرونی', Mazanderani */
         'nqo',  /* N'Ko */

--- a/test/lib/rtl-detect-private_test.js
+++ b/test/lib/rtl-detect-private_test.js
@@ -234,7 +234,7 @@ describe('rtl-detect', function() {
 
         it('_BIDI_RTL_LANGS', function () {
             assert.isArray(RtlDetect._BIDI_RTL_LANGS);
-            assert.lengthOf(RtlDetect._BIDI_RTL_LANGS, 19);
+            assert.lengthOf(RtlDetect._BIDI_RTL_LANGS, 20);
             assert.include(RtlDetect._BIDI_RTL_LANGS, 'ae');
             assert.include(RtlDetect._BIDI_RTL_LANGS, 'ar');
             assert.include(RtlDetect._BIDI_RTL_LANGS, 'arc');
@@ -245,6 +245,7 @@ describe('rtl-detect', function() {
             assert.include(RtlDetect._BIDI_RTL_LANGS, 'fa');
             assert.include(RtlDetect._BIDI_RTL_LANGS, 'glk');
             assert.include(RtlDetect._BIDI_RTL_LANGS, 'he');
+            assert.include(RtlDetect._BIDI_RTL_LANGS, 'iw');
             assert.include(RtlDetect._BIDI_RTL_LANGS, 'ku');
             assert.include(RtlDetect._BIDI_RTL_LANGS, 'mzn');
             assert.include(RtlDetect._BIDI_RTL_LANGS, 'nqo');


### PR DESCRIPTION
I just find that we are using code 'iw' for Hebrew. But in this lib it's 'he'. According to [wikipedia-iw](https://en.wikipedia.org/wiki/IW), 'iw' is "Hebrew language (former ISO 639 language code; changed to HE)". So I think the ''iw should be added to _BIDI_RTL_LANGS array.