### PR TITLE
feature: handle 'iw' - the old ISO-639 code for Hebrew

### DIFF
--- a/lib/rtl-detect.js
+++ b/lib/rtl-detect.js
@@ -151,6 +151,7 @@ Object.defineProperty(self, '_BIDI_RTL_LANGS', {
         'fa',   /* 'فارسی', Persian */
         'glk',  /* 'گیلکی', Gilaki */
         'he',   /* 'עברית', Hebrew */
+        'iw',   /* 'עברית', Hebrew - "iw" is the old ISO-639 language abbreviation for Hebrew and "he" is the new one */
         'ku',   /* 'Kurdî / كوردی', Kurdish */
         'mzn',  /* 'مازِرونی', Mazanderani */
         'nqo',  /* N'Ko */


### PR DESCRIPTION
"iw" is the old ISO-639 language abbreviation for Hebrew and "he" is the new one

e.g. JDK uses the old value in Locale class (https://stackoverflow.com/questions/13974169/jdk-locale-class-handling-of-iso-language-codes-for-hebrew-he-yiddish-yi-an)

I've added this code to the list `BIDI_RTL_LANGS`